### PR TITLE
Libra.org has changed faucet API method from GET to POST

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+PORT=3000
+HOST=localhost
+AMOUNT_TO_MINT=100
+DOCKER_IMAGE=kulap/libra_client:0.3
+USE_KULAP_FAUCET=true

--- a/service/faucet.js
+++ b/service/faucet.js
@@ -13,12 +13,11 @@ class Faucet {
   }
 
   async getFaucetFromKulap(amount, address) {
-    // Convert to micro libras
-    const amountInMicro = BigNumber(amount).times(1e6)
-    const url = `https://libraservice3.kulap.io/faucet?amount=${amountInMicro.toString(10)}&address=${address}`
+    const payload = { amount: amount, address: address }
+    const url = `https://libraservice3.kulap.io/mint`
     console.log(`calling faucet ${url}`)
 
-    const response = await axios.get(url)
+    const response = await axios.post(url, payload)
     return response
   }
 }

--- a/service/faucet.js
+++ b/service/faucet.js
@@ -1,17 +1,14 @@
-const axios = require('axios');
-const BigNumber = require('bignumber.js');
+const axios = require('axios')
+const BigNumber = require('bignumber.js')
 
 class Faucet {
-  constructor () {
-  }
-
   async getFaucetFromLibraTestnet(amount, address) {
     // Convert to micro libras
     const amountInMicro = BigNumber(amount).times(1e6)
     const url = `http://faucet.testnet.libra.org?amount=${amountInMicro.toString(10)}&address=${address}`
     console.log(`calling faucet ${url}`)
 
-    const response = await axios.get(url);
+    const response = await axios.post(url)
     return response
   }
 
@@ -21,7 +18,7 @@ class Faucet {
     const url = `https://libraservice3.kulap.io/faucet?amount=${amountInMicro.toString(10)}&address=${address}`
     console.log(`calling faucet ${url}`)
 
-    const response = await axios.get(url);
+    const response = await axios.get(url)
     return response
   }
 }


### PR DESCRIPTION
Ref issue: https://community.libra.org/t/minting-service-throws-a-405-error/1541/4

- Change method from `GET` to `POST`.